### PR TITLE
Custom scalar serialization

### DIFF
--- a/quiz/build.py
+++ b/quiz/build.py
@@ -390,6 +390,8 @@ def escape(txt):
 @singledispatch
 def argument_as_gql(obj):
     # type: object -> str
+    if hasattr(obj, '__serialized__'):
+        return obj.__serialized__()
     raise TypeError("cannot serialize to GraphQL: {}".format(type(obj)))
 
 

--- a/quiz/types.py
+++ b/quiz/types.py
@@ -186,7 +186,16 @@ class GenericScalarMeta(type):
 
 @six.add_metaclass(GenericScalarMeta)
 class GenericScalar(object):
-    pass
+
+    def __init__(self, value):
+        self.value = value
+
+    def __serialized__(self):
+        raise NotImplementedError()
+
+    @classmethod
+    def add_serialization(cls, serialize_func):
+        cls.__serialized__ = serialize_func
 
 
 def _unwrap_list_or_nullable(type_):

--- a/quiz/types.py
+++ b/quiz/types.py
@@ -187,7 +187,7 @@ class GenericScalarMeta(type):
 @six.add_metaclass(GenericScalarMeta)
 class GenericScalar(object):
 
-    def __init__(self, value):
+    def __init__(self, value=None):
         self.value = value
 
     def __serialized__(self):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -258,12 +258,11 @@ class TestArgumentAsGql:
         assert quiz.argument_as_gql(MyEnum.BLA) == 'QUX'
 
     def test_custom_scalar(self):
-        
         class MyCustomScalar(quiz.GenericScalar):
             """a custom scalar string"""
 
         MyCustomScalar.add_serialization(lambda self: self.value.upper())
-        assert quiz.argument_as_gql(MyCustomScalar('Hello')) == 'HELLO' 
+        assert quiz.argument_as_gql(MyCustomScalar('Hello')) == 'HELLO'
 
 
 class TestQuery:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -257,6 +257,14 @@ class TestArgumentAsGql:
 
         assert quiz.argument_as_gql(MyEnum.BLA) == 'QUX'
 
+    def test_custom_scalar(self):
+        
+        class MyCustomScalar(quiz.GenericScalar):
+            """a custom scalar string"""
+
+        MyCustomScalar.add_serialization(lambda self: self.value.upper())
+        assert quiz.argument_as_gql(MyCustomScalar('Hello')) == 'HELLO' 
+
 
 class TestQuery:
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -56,6 +56,10 @@ class TestGenericScalar:
         class MyScalar(quiz.GenericScalar):
             """foo"""
 
+        with pytest.raises(NotImplementedError):
+            MyScalar.__serialized__()
+        MyScalar.add_serialization(lambda self: self.value.upper())
+
         assert isinstance(4, MyScalar)
         assert isinstance(u'foo', MyScalar)
         assert isinstance(0.1, MyScalar)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -57,7 +57,7 @@ class TestGenericScalar:
             """foo"""
 
         with pytest.raises(NotImplementedError):
-            MyScalar.__serialized__()
+            MyScalar().__serialized__()
         MyScalar.add_serialization(lambda self: self.value.upper())
 
         assert isinstance(4, MyScalar)


### PR DESCRIPTION
Hello,
Thanks for making this great project! It has saved me a bunch of time integrating my GraphQL API into a Flask web app.

One thing I can't do right now is use one of my GraphQL scalar types which represents a JS object. I would like to use this object as a query parameter. For example, I want to do something like this:
```
query[
    _
    .people(where=schema.WhereJSON({'name': {'in': ['Mike', John', 'Willis']}}))[
        age,
        favoriteFood
    ]
]
```

This PR is what I came up with to get this to work, perhaps a starting point? This pattern for setting the serialization works well in my use case, I just add `schema.WhereJSON.add_serialization(lambda x: json.dumps(x).replace('"', ''))` and it works.

This should probably be paired with a de-serialization method, e.g. following this pattern a `__deserialize__` method, I am not sure what part of the code deserialization happens so I didn't add it yet.

Release checklist (if applicable)

- [ ] Issue(s) referenced (optional)
- [ ] Implementation done
- [ ] Changelog updated
- [ ] Version bump in `__about__.py`
- [ ] CI checks OK
- [ ] PR merged
- [ ] Branch deleted
- [ ] Tag added
- [ ] Release published
